### PR TITLE
SecOC de init

### DIFF
--- a/source/SecOC.c
+++ b/source/SecOC.c
@@ -215,6 +215,7 @@ void SecOC_DeInit(void)
 
     SecOCState = SECOC_UNINIT;
 
+    // [SWS_SecOC_00157]
     // Emptying Tx/Rx buffers
     PduIdType idx;
     for (idx = 0 ; idx < SECOC_NUM_OF_TX_PDU_PROCESSING; idx++) 
@@ -231,8 +232,6 @@ void SecOC_DeInit(void)
         securedPdu->SduLength = 0;
     }
 
-
-    // [SWS_SecOC_00157]
     SecOCGeneral = NULL;
     SecOCTxPduProcessing = NULL;
     SecOCRxPduProcessing = NULL;


### PR DESCRIPTION
Added SecOC_DeInit and checks in main functions
Test:
I added two printf functions in mainfunctionTx and mainfunctionRx respectively:
```C
    printf("Entered SecOCMainFunctionRx\n");
    printf("Entered SecOCMainFunctionRx\n");
```

test code:
```C
extern SecOC_ConfigType SecOC_Config;
void SecOC_test()
{
    SecOC_Init(&SecOC_Config);
    printf("Initalized:\n");

    SecOCMainFunctionTx();
    SecOCMainFunctionRx();

    SecOC_DeInit();
    printf("DeInitalized:\n");
    SecOCMainFunctionTx();
    SecOCMainFunctionRx();

    printf("Initalized:\n");
    SecOC_Init(&SecOC_Config);
    SecOCMainFunctionTx();
    SecOCMainFunctionRx();


}
```
The code responded successfully by not printing the "Entered" message when deinited and enters only when Inited.
Output:
```C
Initalized:
Entered SecOCMainFunctionTx
Entered SecOCMainFunctionRx
DeInitalized:
Initalized:
Entered SecOCMainFunctionTx
Entered SecOCMainFunctionRx
Program ran successfully
```