### PR TITLE
Fix bug

### DIFF
--- a/source/SecOC/SecOC.c
+++ b/source/SecOC/SecOC.c
@@ -1213,7 +1213,7 @@ void SecOC_MainFunctionRx(void)
                 #endif
 
                 /* [SWS_SecOC_00241] */
-                if( SecOC_RxCounters[idx].VerificationCounter == SecOCRxPduProcessing[idx].SecOCAuthenticationVerifyAttempts )
+                if( SecOC_RxCounters[idx].VerificationCounter >= SecOCRxPduProcessing[idx].SecOCAuthenticationVerifyAttempts )
                 {
                     securedPdu->SduLength = 0;
                 }


### PR DESCRIPTION
### If the configuration of SecOCAuthenticationBuildAttempts and SecOCAuthenticationVerifyAttempts == 0 
### SecOC will save buffer in its buffer and will not discard the message and this solve it